### PR TITLE
Feat/#3  서비스에 필요한 초기 데이터 클래스 추가

### DIFF
--- a/src/main/java/com/bookspot/batch/data/LibraryBook.java
+++ b/src/main/java/com/bookspot/batch/data/LibraryBook.java
@@ -3,9 +3,13 @@ package com.bookspot.batch.data;
 
 import com.bookspot.batch.data.book.Isbn13;
 import com.bookspot.batch.data.library.LibraryCode;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+@Data
+@NoArgsConstructor
 public class LibraryBook {
     private Isbn13 isbn13;
     private LibraryCode libraryCode;

--- a/src/main/java/com/bookspot/batch/data/LibraryBook.java
+++ b/src/main/java/com/bookspot/batch/data/LibraryBook.java
@@ -1,10 +1,12 @@
 package com.bookspot.batch.data;
 
 
+import com.bookspot.batch.data.book.Isbn13;
+
 import java.time.LocalDate;
 
 public class LibraryBook {
-    private String isbn13;
+    private Isbn13 isbn13;
     private String libraryCode;
     private int loanCount;          // 10
     private LocalDate registrationDate; // 2024-11-29

--- a/src/main/java/com/bookspot/batch/data/LibraryBook.java
+++ b/src/main/java/com/bookspot/batch/data/LibraryBook.java
@@ -1,0 +1,11 @@
+package com.bookspot.batch.data;
+
+
+import java.time.LocalDate;
+
+public class LibraryBook {
+    private String isbn13;
+    private String libraryCode;
+    private int loanCount;          // 10
+    private LocalDate registrationDate; // 2024-11-29
+}

--- a/src/main/java/com/bookspot/batch/data/LibraryBook.java
+++ b/src/main/java/com/bookspot/batch/data/LibraryBook.java
@@ -2,12 +2,13 @@ package com.bookspot.batch.data;
 
 
 import com.bookspot.batch.data.book.Isbn13;
+import com.bookspot.batch.data.library.LibraryCode;
 
 import java.time.LocalDate;
 
 public class LibraryBook {
     private Isbn13 isbn13;
-    private String libraryCode;
+    private LibraryCode libraryCode;
     private int loanCount;          // 10
     private LocalDate registrationDate; // 2024-11-29
 }

--- a/src/main/java/com/bookspot/batch/data/book/Book.java
+++ b/src/main/java/com/bookspot/batch/data/book/Book.java
@@ -3,18 +3,13 @@ package com.bookspot.batch.data.book;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-
 @Data
 @NoArgsConstructor
 public class Book {
     private String isbn13;          // 9788954605816
-    private int volume;             // 3
-    private String title;           // 눈물상자
+    private String title;           // 눈물상자 (제목 + 권 수)
     private String author;          // 한강 글 ;봄로야 그림
     private String publisher;       // 문학동네
     private int publicationYear;    // 2021
-    private int loanCount;          // 10
-    private LocalDate registrationDate; // 2024-11-29
     private String subjectCode; // 813.7
 }

--- a/src/main/java/com/bookspot/batch/data/book/Book.java
+++ b/src/main/java/com/bookspot/batch/data/book/Book.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class Book {
-    private String isbn13;          // 9788954605816
+    private Isbn13 isbn13;          // 9788954605816
     private String title;           // 눈물상자 (제목 + 권 수)
     private String author;          // 한강 글 ;봄로야 그림
     private String publisher;       // 문학동네

--- a/src/main/java/com/bookspot/batch/data/book/Book.java
+++ b/src/main/java/com/bookspot/batch/data/book/Book.java
@@ -1,0 +1,20 @@
+package com.bookspot.batch.data.book;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class Book {
+    private String isbn13;          // 9788954605816
+    private int volume;             // 3
+    private String title;           // 눈물상자
+    private String author;          // 한강 글 ;봄로야 그림
+    private String publisher;       // 문학동네
+    private int publicationYear;    // 2021
+    private int loanCount;          // 10
+    private LocalDate registrationDate; // 2024-11-29
+    private String subjectCode; // 813.7
+}

--- a/src/main/java/com/bookspot/batch/data/book/Isbn13.java
+++ b/src/main/java/com/bookspot/batch/data/book/Isbn13.java
@@ -1,0 +1,11 @@
+package com.bookspot.batch.data.book;
+
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Isbn13 {
+    private String code;
+}

--- a/src/main/java/com/bookspot/batch/data/library/Library.java
+++ b/src/main/java/com/bookspot/batch/data/library/Library.java
@@ -6,7 +6,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class Library {
-    private String libraryCode;
+    private LibraryCode code;
     private String address;
     private String tel;
     private double latitude;

--- a/src/main/java/com/bookspot/batch/data/library/Library.java
+++ b/src/main/java/com/bookspot/batch/data/library/Library.java
@@ -1,0 +1,17 @@
+package com.bookspot.batch.data.library;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Library {
+    private String libraryCode;
+    private String address;
+    private String tel;
+    private double latitude;
+    private double longitude;
+    private String homePage;
+    private String closedInfo;
+    private String operatingInfo;
+}

--- a/src/main/java/com/bookspot/batch/data/library/LibraryCode.java
+++ b/src/main/java/com/bookspot/batch/data/library/LibraryCode.java
@@ -1,0 +1,10 @@
+package com.bookspot.batch.data.library;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class LibraryCode {
+    private String code;
+}


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #3 
- 파싱 데이터 구조 파악과 서비스에 필요한 데이터 파악을 위해 데이터 클래스를 먼저 추가해본다.

## 이 PR에서 다루지 않는 것
- 필드 중심으로 구성했기 떄문에 메소드 및 필드 캡슐화 부분은 다루지 않는다.

## 이후 PR 계획
- 해당 클래스를 기반으로 데이터를 가져와서 DB에 저장할 예정이다.

<!--
 (optional) 참고한 사이트
## 참고
-
-->
 
