### PR TITLE
Fix/#37 OpenSearch 책 정보 동기화 작업에서 비효율적인 findAll(Pageable)로 RDS 크레딧 소진 현상 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Delete 파일 생성 Step에서 사용하는 Map을 Map<Long, Boolean> => LongBo
 
 - OpenSearch 인덱스 생성 Step
   - (25년 6월 기준) books-2025-06 인덱스 생성
-- OpenSearch 동기화 Step (ChunkSize - 500)
+- OpenSearch 동기화 Step (ChunkSize - 250)
   - Reader: 책 테이블 정보 읽기
   - Processor: Document로 변환하기
   - Writer: OpenSearch로 Bulk Insert

--- a/src/main/java/com/bookspot/batch/step/BookOpenSearchSyncStepConfig.java
+++ b/src/main/java/com/bookspot/batch/step/BookOpenSearchSyncStepConfig.java
@@ -8,6 +8,7 @@ import com.bookspot.batch.step.listener.StepLoggingListener;
 import com.bookspot.batch.step.listener.alert.AlertStepListener;
 import com.bookspot.batch.step.reader.BookWithLibraryIdReader;
 import com.bookspot.batch.step.service.*;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -36,7 +37,7 @@ public class BookOpenSearchSyncStepConfig {
     private final PlatformTransactionManager transactionManager;
     private final StepLoggingListener stepLoggingListener;
 
-    private final BookRepository bookRepository;
+    private final EntityManager entityManager;
     private final LibraryStockRepository libraryStockRepository;
 
     private final OpenSearchRepository openSearchRepository;
@@ -81,7 +82,7 @@ public class BookOpenSearchSyncStepConfig {
     @StepScope
     public BookWithLibraryIdReader bookWithLibraryIdReader() {
         return new BookWithLibraryIdReader(
-                bookRepository,
+                entityManager,
                 libraryStockRepository,
                 bookCodeResolver(),
                 CHUNK_SIZE

--- a/src/main/java/com/bookspot/batch/step/BookOpenSearchSyncStepConfig.java
+++ b/src/main/java/com/bookspot/batch/step/BookOpenSearchSyncStepConfig.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @Configuration
 @RequiredArgsConstructor
 public class BookOpenSearchSyncStepConfig {
-    private static final int CHUNK_SIZE = 500;
+    private static final int CHUNK_SIZE = 250;
     private static final int RETRY_LIMIT = 5;
     private static final long BACK_OFF_DELAY = 250L;
 


### PR DESCRIPTION
## PR 목적 (# 이슈번호)
- #37 

## 이후 PR 계획
- 데이터를 밀어넣은 후 index alias나 삭제 생성에 대한 예외 핸들링 필요

## 참고
- [velog 내 글 - Batch 처리 시 findAll(pageable)로 인한 RDS 버스트 크레딧 문제 해결](https://velog.io/@sdsd0908/Batch-%EC%B2%98%EB%A6%AC-%ED%8E%98%EC%9D%B4%EC%A7%95-%EC%BF%BC%EB%A6%AC%EC%99%80-RDS-%EB%B2%84%EC%8A%A4%ED%8A%B8-%ED%81%AC%EB%A0%88%EB%94%A7-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)
 
